### PR TITLE
Add OpenSSL 1.1 support

### DIFF
--- a/src/CRLData.cpp
+++ b/src/CRLData.cpp
@@ -255,7 +255,11 @@ CRLData::getExtensionsAsText() const
 	unsigned int n = 0;
 	BIO *bio = BIO_new(BIO_s_mem());
 
+	#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+	X509V3_extensions_print(bio, NULL, X509_CRL_get0_extensions(m_impl->x509), 0, 4);
+	#else
 	X509V3_extensions_print(bio, NULL, m_impl->x509->crl->extensions, 0, 4);
+	#endif
 	n = BIO_get_mem_data(bio, &ustringval);
 
 	std::string extText = std::string((const char*)ustringval, n);

--- a/src/CRLReason_Priv.cpp
+++ b/src/CRLReason_Priv.cpp
@@ -57,7 +57,11 @@ CRLReason_Priv::CRLReason_Priv(STACK_OF(X509_EXTENSION) *stack)
 		char            obj_tmp[80];
 		BIO            *out;
 
+		#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+		i2t_ASN1_OBJECT(obj_tmp, 80, X509_EXTENSION_get_object(xe));
+		#else
 		i2t_ASN1_OBJECT(obj_tmp, 80, xe->object);
+		#endif
 		nid = OBJ_txt2nid(obj_tmp);
 
 		LOGIT_DEBUG("NID: " << obj_tmp << " " << nid);

--- a/src/CertificateData.cpp
+++ b/src/CertificateData.cpp
@@ -202,7 +202,11 @@ CertificateData::getExtensionsAsText() const
 	unsigned int n = 0;
 	BIO *bio = BIO_new(BIO_s_mem());
 
+	#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+	X509V3_extensions_print(bio, NULL, X509_get0_extensions(m_impl->x509), 0, 4);
+	#else
 	X509V3_extensions_print(bio, NULL, m_impl->x509->cert_info->extensions, 0, 4);
+	#endif
 	n = BIO_get_mem_data(bio, &ustringval);
 
 	std::string extText = std::string((const char*)ustringval, n);


### PR DESCRIPTION
This commit adds support for building libcamgm against openssl 1.1.0, which will become the default openssl on Factory and subsequently on SLE-15.
https://bugzilla.suse.com/show_bug.cgi?id=1042655

A package with this patch successfully builds in OBS: /home/vcizek/OBS/home:vitezslav_cizek:branches:devel:libraries:c_c++/libcamgm 

As for functionality, I made some minimal testing by running yast2 ca_mgm.
The package's testsuite gives quite a few failures, but some tests did fail also with openssl 1.0.1 and the testsuite result is ignored in %check nowadays anyway.
I haven't dug much into it. We should however examine the test failures.
